### PR TITLE
Implement status manager

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
         "start": "node server/server.js"
     },
     "dependencies": {
+        "body-parser": "^1.18.3",
         "express": "^4.16.3",
         "vue": "^2.5.16"
     }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "dependencies": {
         "body-parser": "^1.18.3",
         "express": "^4.16.3",
+        "validate.js": "^0.12.0",
         "vue": "^2.5.16"
     }
 }

--- a/server/domain/Events.js
+++ b/server/domain/Events.js
@@ -1,0 +1,34 @@
+const events = require('events');
+const eventEmitter = new events.EventEmitter();
+
+class Events {
+    constructor() {
+        this.setEvents();
+    }
+
+    setEvents() {
+        this.event = {
+            newStatus: 'new-status',
+        };
+    }
+
+    push(eventName, ...data) {
+        console.log(`[Events] Pushing ${eventName}...`);
+
+        eventEmitter.emit(eventName, ...data);
+    }
+
+    watch(eventName, eventHandler) {
+        console.log(`[Events] Watching ${eventName}...`);
+
+        eventEmitter.on(eventName, eventHandler);
+    }
+
+    waitFor(eventName, eventHandler) {
+        console.log(`[Events] Waiting for ${eventName}...`);
+
+        eventEmitter.once(eventName, eventHandler);
+    }
+}
+
+module.exports = new Events();

--- a/server/domain/status/Status.js
+++ b/server/domain/status/Status.js
@@ -33,6 +33,8 @@ class Status {
                 return newStatus;
             })
             .catch(errors => {
+                console.log('[Status] Validation failed, throwing error.');
+
                 throw {
                     message: 'The new status is not valid, please check the errors.',
                     errors: errors,

--- a/server/domain/status/Status.js
+++ b/server/domain/status/Status.js
@@ -1,0 +1,44 @@
+const validate = require('validate.js');
+
+class Status {
+    constructor(data) {
+        this.data = data;
+    }
+
+    static getConstraints() {
+        return {
+            key: {
+                presence: true,
+            },
+            state: {
+                presence: true,
+            },
+        };
+    }
+
+    static createStatus(data) {
+        console.log('[Status] Creating status...');
+
+        return validate
+            .async(data, this.getConstraints())
+            .then(data => {
+                // @todo: Push new status into a new listener
+
+                console.log('[Status] Successfully added!');
+
+                return new this(data);
+            })
+            .catch(errors => {
+                throw {
+                    message: 'The new status is not valid, please check the errors.',
+                    errors: errors,
+                };
+            });
+    }
+
+    getData() {
+        return this.data;
+    }
+}
+
+module.exports = Status;

--- a/server/domain/status/Status.js
+++ b/server/domain/status/Status.js
@@ -1,4 +1,5 @@
 const validate = require('validate.js');
+const Events = require('../Events');
 
 class Status {
     constructor(data) {
@@ -22,9 +23,10 @@ class Status {
         return validate
             .async(data, this.getConstraints())
             .then(data => {
+                data = { ...data, time: new Date() };
                 const newStatus = new this(data);
 
-                // @todo: Push new status into a new listener
+                Events.push(Events.event.newStatus, newStatus);
 
                 console.log('[Status] Successfully added!');
 
@@ -38,8 +40,12 @@ class Status {
             });
     }
 
-    getData() {
+    getRawData() {
         return this.data;
+    }
+
+    getKey() {
+        return this.data.key;
     }
 }
 

--- a/server/domain/status/Status.js
+++ b/server/domain/status/Status.js
@@ -22,11 +22,13 @@ class Status {
         return validate
             .async(data, this.getConstraints())
             .then(data => {
+                const newStatus = new this(data);
+
                 // @todo: Push new status into a new listener
 
                 console.log('[Status] Successfully added!');
 
-                return new this(data);
+                return newStatus;
             })
             .catch(errors => {
                 throw {

--- a/server/domain/status/StatusManager.js
+++ b/server/domain/status/StatusManager.js
@@ -3,6 +3,7 @@ class StatusManager {
         this.statuses = [];
 
         // @todo: Listen to creation of new statuses
+        console.log('[StatusManager] Listening to incoming statuses...');
     }
 }
 

--- a/server/domain/status/StatusManager.js
+++ b/server/domain/status/StatusManager.js
@@ -1,13 +1,8 @@
 class StatusManager {
     constructor() {
         this.statuses = [];
-    }
 
-    addStatus(statusData) {
-        console.log('[StatusManager] Add new status...');
-        return new Promise((resolve, reject) => {
-            // Create new status object
-        });
+        // @todo: Listen to creation of new statuses
     }
 }
 

--- a/server/domain/status/StatusManager.js
+++ b/server/domain/status/StatusManager.js
@@ -5,7 +5,16 @@ class StatusManager {
     constructor() {
         this.statuses = [];
 
-        Events.watch(Events.event.newStatus, status => this.processStatus(status));
+        this.setListeners();
+    }
+
+    setListeners() {
+        Events.watch(Events.event.newStatus, status => {
+            console.log('[StatusManager] Received new status.');
+
+            this.processStatus(status);
+        });
+
         console.log('[StatusManager] Listening to incoming statuses...');
     }
 
@@ -13,16 +22,16 @@ class StatusManager {
      * @param {Status} status
      */
     processStatus(status) {
-        console.log('[EventManager] Received new status!');
-
-        // If the status key already exists, overwrite it
         const existingStatusByKey = this.statuses.find(existingStatus => existingStatus.getKey() === status.getKey());
+
         if (existingStatusByKey) {
+            console.log('[StatusManager] Status already exists, replacing the old status.');
             const index = this.statuses.indexOf(existingStatusByKey);
             this.statuses[index] = status;
             return;
         }
 
+        console.log('[StatusManager] Adding new status to the statuses.');
         this.statuses.push(status);
     }
 }

--- a/server/domain/status/StatusManager.js
+++ b/server/domain/status/StatusManager.js
@@ -1,9 +1,29 @@
+const Events = require('../Events');
+const Status = require('./Status');
+
 class StatusManager {
     constructor() {
         this.statuses = [];
 
-        // @todo: Listen to creation of new statuses
+        Events.watch(Events.event.newStatus, status => this.processStatus(status));
         console.log('[StatusManager] Listening to incoming statuses...');
+    }
+
+    /**
+     * @param {Status} status
+     */
+    processStatus(status) {
+        console.log('[EventManager] Received new status!');
+
+        // If the status key already exists, overwrite it
+        const existingStatusByKey = this.statuses.find(existingStatus => existingStatus.getKey() === status.getKey());
+        if (existingStatusByKey) {
+            const index = this.statuses.indexOf(existingStatusByKey);
+            this.statuses[index] = status;
+            return;
+        }
+
+        this.statuses.push(status);
     }
 }
 

--- a/server/domain/status/StatusManager.js
+++ b/server/domain/status/StatusManager.js
@@ -1,0 +1,14 @@
+class StatusManager {
+    constructor() {
+        this.statuses = [];
+    }
+
+    addStatus(statusData) {
+        console.log('[StatusManager] Add new status...');
+        return new Promise((resolve, reject) => {
+            // Create new status object
+        });
+    }
+}
+
+module.exports = new StatusManager();

--- a/server/routes/dashboard.js
+++ b/server/routes/dashboard.js
@@ -1,0 +1,13 @@
+const express = require('express');
+const app = (module.exports = express());
+const path = require('path');
+
+// Listen to all the statically generated files
+app.use(express.static('dist'));
+
+// When directly opening the applications index, show the dashboard
+app.get('/', (req, res) => {
+    console.log('/ [GET]');
+
+    return res.sendFile(path.resolve(__dirname + '/../../monitor/index.html'));
+});

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -3,7 +3,7 @@ const app = (module.exports = require('express')());
 app.get('/test', (request, response) => {
     console.log('/test [GET]');
 
-    response.send({ message: 'Hello, this is a test.' });
+    response.json({ message: 'Hello, this is a test.' });
 });
 
 app.use('/status', require('./status'));

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -1,0 +1,8 @@
+const app = (module.exports = require('express')());
+
+app.get('/test', (request, response) => {
+    console.log('TEST');
+    response.send({
+        message: 'Hello, this is a test.',
+    });
+});

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -1,9 +1,4 @@
 const app = (module.exports = require('express')());
 
-app.get('/test', (request, response) => {
-    console.log('/test [GET]');
-
-    response.json({ message: 'Hello, this is a test.' });
-});
-
+app.use('/', require('./dashboard'));
 app.use('/status', require('./status'));

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -1,8 +1,9 @@
 const app = (module.exports = require('express')());
 
 app.get('/test', (request, response) => {
-    console.log('TEST');
-    response.send({
-        message: 'Hello, this is a test.',
-    });
+    console.log('/test [GET]');
+
+    response.send({ message: 'Hello, this is a test.' });
 });
+
+app.use('/status', require('./status'));

--- a/server/routes/status.js
+++ b/server/routes/status.js
@@ -1,7 +1,12 @@
 const app = (module.exports = require('express')());
+const StatusManager = require('../domain/status/StatusManager');
 
 app.post('/', (request, response) => {
     console.log('/status [POST]');
+
+    console.log(request.body);
+
+    StatusManager.addStatus(request.body);
 
     // @todo: Use sexy promise!
     // addStatus(request.body)

--- a/server/routes/status.js
+++ b/server/routes/status.js
@@ -8,7 +8,7 @@ app.post('/', (request, response) => {
         .then(status =>
             response.json({
                 message: 'Successfully pushed your status!',
-                status: status.getData(),
+                status: status.getRawData(),
             }),
         )
         .catch(error => response.status(422).json(error));

--- a/server/routes/status.js
+++ b/server/routes/status.js
@@ -1,23 +1,21 @@
 const app = (module.exports = require('express')());
-const StatusManager = require('../domain/status/StatusManager');
+const Status = require('../domain/status/Status');
 
 app.post('/', (request, response) => {
     console.log('/status [POST]');
 
-    console.log(request.body);
-
-    StatusManager.addStatus(request.body);
-
-    // @todo: Use sexy promise!
-    // addStatus(request.body)
-    //     .then((status) => response.send(status))
-    //     .catch((err) => response.status(422).send({message: 'stuk'}));
-
-    response.send({ message: 'New status is WIP.' });
+    Status.createStatus(request.body)
+        .then(status =>
+            response.json({
+                message: '',
+                status: status.getData(),
+            }),
+        )
+        .catch(error => response.status(422).json(error));
 });
 
 app.get('/', (request, response) => {
     console.log('/status [GET]');
 
-    response.send({ message: 'You can only view the statuses via the dashboard.' });
+    response.json({ message: 'You can only view the statuses via the dashboard.' });
 });

--- a/server/routes/status.js
+++ b/server/routes/status.js
@@ -7,7 +7,7 @@ app.post('/', (request, response) => {
     Status.createStatus(request.body)
         .then(status =>
             response.json({
-                message: '',
+                message: 'Successfully pushed your status!',
                 status: status.getData(),
             }),
         )

--- a/server/routes/status.js
+++ b/server/routes/status.js
@@ -1,0 +1,18 @@
+const app = (module.exports = require('express')());
+
+app.post('/', (request, response) => {
+    console.log('/status [POST]');
+
+    // @todo: Use sexy promise!
+    // addStatus(request.body)
+    //     .then((status) => response.send(status))
+    //     .catch((err) => response.status(422).send({message: 'stuk'}));
+
+    response.send({ message: 'New status is WIP.' });
+});
+
+app.get('/', (request, response) => {
+    console.log('/status [GET]');
+
+    response.send({ message: 'You can only view the statuses via the dashboard.' });
+});

--- a/server/server.js
+++ b/server/server.js
@@ -1,11 +1,14 @@
 const express = require('express');
 const path = require('path');
+const router = require('./routes');
 
 const app = express();
 
 app.use(express.static('dist'));
 
 app.get('/', (req, res) => res.sendFile(path.resolve(__dirname + '/../monitor/index.html')));
+
+app.use(router);
 
 app.listen(9999, () => {
     console.log('===================');

--- a/server/server.js
+++ b/server/server.js
@@ -1,8 +1,11 @@
 const express = require('express');
+const bodyParser = require('body-parser');
 const path = require('path');
 const router = require('./routes');
 
 const app = express();
+
+app.use(bodyParser.json());
 
 app.use(express.static('dist'));
 

--- a/server/server.js
+++ b/server/server.js
@@ -1,20 +1,16 @@
+console.log('[CIMonitor] Started!');
+
 const express = require('express');
 const bodyParser = require('body-parser');
-const path = require('path');
 const router = require('./routes');
+
+const statusManager = require('./domain/status/StatusManager');
 
 const app = express();
 
 app.use(bodyParser.json());
-
-app.use(express.static('dist'));
-
-app.get('/', (req, res) => res.sendFile(path.resolve(__dirname + '/../monitor/index.html')));
-
 app.use(router);
 
 app.listen(9999, () => {
-    console.log('===================');
-    console.log('     CIMonitor     ');
-    console.log('===================\n');
+    console.log('[Express] Ready and listening...');
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1155,6 +1155,22 @@ body-parser@1.18.2:
     raw-body "2.3.2"
     type-is "~1.6.15"
 
+body-parser@^1.18.3:
+  version "1.18.3"
+  resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.18.3.tgz#5b292198ffdd553b3a0f20ded0592b956955c8b4"
+  integrity sha1-WykhmP/dVTs6DyDe0FkrlWlVyLQ=
+  dependencies:
+    bytes "3.0.0"
+    content-type "~1.0.4"
+    debug "2.6.9"
+    depd "~1.1.2"
+    http-errors "~1.6.3"
+    iconv-lite "0.4.23"
+    on-finished "~2.3.0"
+    qs "6.5.2"
+    raw-body "2.3.3"
+    type-is "~1.6.16"
+
 bonjour@^3.5.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/bonjour/-/bonjour-3.5.0.tgz#8e890a183d8ee9a2393b3844c691a42bcf7bc9f5"
@@ -4170,7 +4186,7 @@ http-errors@1.6.2:
     setprototypeof "1.0.3"
     statuses ">= 1.3.1 < 2"
 
-http-errors@1.6.3, http-errors@~1.6.2:
+http-errors@1.6.3, http-errors@~1.6.2, http-errors@~1.6.3:
   version "1.6.3"
   resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.6.3.tgz#8b55680bb4be283a0b5bf4ea2e38580be1d9320d"
   integrity sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=
@@ -6902,15 +6918,15 @@ qs@6.5.1:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.1.tgz#349cdf6eef89ec45c12d7d5eb3fc0c870343a6d8"
   integrity sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==
 
+qs@6.5.2, qs@~6.5.1:
+  version "6.5.2"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
+  integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
+
 qs@~6.4.0:
   version "6.4.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.4.0.tgz#13e26d28ad6b0ffaa91312cd3bf708ed351e7233"
   integrity sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=
-
-qs@~6.5.1:
-  version "6.5.2"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
-  integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
 
 query-string@^4.1.0:
   version "4.3.4"
@@ -6974,7 +6990,7 @@ raw-body@2.3.2:
     iconv-lite "0.4.19"
     unpipe "1.0.0"
 
-raw-body@^2.3.2:
+raw-body@2.3.3, raw-body@^2.3.2:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/raw-body/-/raw-body-2.3.3.tgz#1b324ece6b5706e153855bc1148c65bb7f6ea0c3"
   integrity sha512-9esiElv1BrZoI3rCDuOuKCBRbuApGGaDPQfjSflGxdy4oyzqghxu6klEkkVIvBje+FF0BX9coEv8KqW6X/7njw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -8783,6 +8783,11 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
 
+validate.js@^0.12.0:
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/validate.js/-/validate.js-0.12.0.tgz#17f989e37c192ea2f826bbf19bf4e97e6e4be68f"
+  integrity sha512-/x2RJSvbqEyxKj0RPN4xaRquK+EggjeVXiDDEyrJzsJogjtiZ9ov7lj/svVb4DM5Q5braQF4cooAryQbUwOxlA==
+
 vary@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"


### PR DESCRIPTION
### What

This PR creates the status manager module, responsible for keeping track of all statuses that should be displayed on the dashboard.

You should be able to add a new status via the /status endpoint

### To do

- [x] Create StatusManager object
- [x] Listen to new statuses and add them to the statusmanager
- [x] Create Status object
- [x] Validate incoming statuses
- [x] Return a clean json response
- [x] Move dashboard routes to its own route file

----
Console log:
```
[CIMonitor] Started!
[Events] Watching new-status...
[StatusManager] Listening to incoming statuses...
[Express] Ready and listening...
/status [POST]
[Status] Creating status...
[Events] Pushing new-status...
[StatusManager] Received new status.
[StatusManager] Added new status to the statuses.
[Status] Successfully added!
/status [POST]
[Status] Creating status...
[Events] Pushing new-status...
[StatusManager] Received new status.
[StatusManager] Status already exists, replacing the old status.
[Status] Successfully added!
```